### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # next build runs the TypeScript compiler, so a separate tsc --noEmit
+      # step would only repeat work already done here.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Runs lint and a production build on every pull request and on `main`.

Nothing gates this repo today, so a broken change reaches `main` and shows up as a failed Netlify deploy. This catches it at the PR instead.

No separate `tsc --noEmit` — `next build` already typechecks.

Verified locally: lint clean, build compiles, all 5 pages static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
