### PR TITLE
Point the footer resume link at the new resume site

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
         <ul>
           <li><a href="https://linkedin.com/in/abdullah-morrison" target="_blank">LinkedIn</a></li>
           <li><a href="https://github.com/abdullahmorrison" target="_blank">GitHub</a></li>
-          <li><a href="https://www.overleaf.com/read/wgtzgrzyfprt#f54c1b" target='_blank'>My Resume</a></li>
+          <li><a href="https://abdullahmorrison.github.io/resume/" target="_blank">My Resume</a></li>
         </ul>
         <p>This website was made with NextJS.</p>
       </footer>


### PR DESCRIPTION
Swaps the footer's Overleaf read-only link for the resume site:

```
https://abdullahmorrison.github.io/resume/
```

It rebuilds from LaTeX source on every push and serves the PDF as `application/pdf`, so it opens in the browser instead of downloading.

Also normalizes `target='_blank'` to double quotes, matching the two links above it.

Verified locally: lint clean, build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
