### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+name: pr-title
+
+# Squash merging uses the PR title as the commit subject, so validating the
+# title is what actually keeps main's history conventional.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate conventional commit format
+        # Passed through the environment rather than interpolated into the
+        # script, so a title containing shell metacharacters cannot execute.
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?!?: .+'
+          if printf '%s' "$TITLE" | grep -qE "$pattern"; then
+            echo "OK: $TITLE"
+            exit 0
+          fi
+          echo "PR title does not follow Conventional Commits:"
+          echo
+          echo "    $TITLE"
+          echo
+          echo "Expected:  <type>[(scope)][!]: <description>"
+          echo "Types:     feat fix docs style refactor perf test build ci chore revert"
+          echo "Example:   feat(footer): link to the resume site"
+          echo
+          echo "Edit the PR title and this check reruns automatically."
+          exit 1


### PR DESCRIPTION
Validates PR titles against Conventional Commits.

```
<type>[(scope)][!]: <description>
```

Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `revert`

Merging is squash-only with the PR title as the commit subject, so the title is what lands on `main`. Validating branch commits would enforce nothing about the resulting history.

Two implementation choices worth knowing:

- Inline regex, not a third-party action — no supply-chain dependency for one grep.
- The title comes in via `env:`, never interpolated into the script, so a title containing backticks or `$()` can't execute.

Reruns on `edited`, so fixing a bad title revalidates automatically.

Regex verified against 8 cases: `feat: x`, `fix(footer): x`, `ci!: x`, `chore(deps): x` pass; `Add CI workflow`, `feat add thing`, `feat:`, `random: nope` fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
