### PR TITLE
feat: add contact page

### DIFF
--- a/public/__forms.html
+++ b/public/__forms.html
@@ -1,0 +1,18 @@
+<html>
+  <head></head>
+  <body>
+    <!--
+      Netlify detects forms by scanning static HTML at deploy time. The real
+      form is rendered by React, which that scan never sees, so it is declared
+      here as well. Nobody visits this page; it exists only to be parsed.
+      Field names must stay in sync with src/app/contact/contact-form.tsx.
+    -->
+    <form name="contact" data-netlify="true" data-netlify-honeypot="bot-field" hidden>
+      <input type="hidden" name="form-name" value="contact" />
+      <input type="text" name="bot-field" />
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <textarea name="message"></textarea>
+    </form>
+  </body>
+</html>

--- a/src/app/components/nav/nav.tsx
+++ b/src/app/components/nav/nav.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import styles from './nav.module.scss'
 
 export default function nav() {
@@ -6,10 +7,10 @@ export default function nav() {
       <h4 className={styles.logo}>My Portfolio</h4>
       <ul>
         <li>
-          <h5><a href="">Home</a></h5>
+          <h5><Link href="/">Home</Link></h5>
         </li>
         <li>
-          <h5><a href="mailto:abdullahmorrison@gmail.com">Contact</a></h5>
+          <h5><Link href="/contact">Contact</Link></h5>
         </li>
       </ul>
     </nav>

--- a/src/app/contact/contact-form.tsx
+++ b/src/app/contact/contact-form.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+import styles from './contact.module.scss'
+
+type Status = 'idle' | 'sending' | 'sent' | 'error'
+
+export default function ContactForm() {
+  const [status, setStatus] = useState<Status>('idle')
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('sending')
+
+    const formData = new FormData(event.currentTarget)
+
+    try {
+      // Posts to the static file Netlify scanned at deploy time, not to this route.
+      const response = await fetch('/__forms.html', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(formData as unknown as Record<string, string>).toString(),
+      })
+      if (!response.ok) throw new Error(`Netlify responded ${response.status}`)
+      setStatus('sent')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <p className={styles.sent}>
+        Thanks — your message is on its way. I&apos;ll get back to you.
+      </p>
+    )
+  }
+
+  return (
+    <form name="contact" className={styles.form} onSubmit={handleSubmit}>
+      <input type="hidden" name="form-name" value="contact" />
+      <p className={styles.honeypot}>
+        <label>
+          Leave this empty
+          <input type="text" name="bot-field" tabIndex={-1} autoComplete="off" />
+        </label>
+      </p>
+
+      <label className={styles.field}>
+        <span>Name</span>
+        <input type="text" name="name" required autoComplete="name" />
+      </label>
+
+      <label className={styles.field}>
+        <span>Email</span>
+        <input type="email" name="email" required autoComplete="email" />
+      </label>
+
+      <label className={styles.field}>
+        <span>Message</span>
+        <textarea name="message" rows={6} required />
+      </label>
+
+      <button type="submit" className={styles.submit} disabled={status === 'sending'}>
+        {status === 'sending' ? 'Sending…' : 'Send'}
+      </button>
+
+      {status === 'error' && (
+        <p className={styles.error}>
+          Something went wrong. Email me directly at{' '}
+          <a href="mailto:abdullahmorrison@gmail.com">abdullahmorrison@gmail.com</a>.
+        </p>
+      )}
+    </form>
+  )
+}

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -10,62 +10,92 @@
 
 .body {
     flex: 1;
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 60px;
+    gap: 40px;
 }
 
 .title {
-    display: grid;
     line-height: 1;
-
-    span {
-        overflow: hidden;
-    }
-    span p {
-        animation: slideUp 0.75s ease-out;
-    }
-    .accent p {
-        color: $title-accent;
-        animation: slideDown 1.5s ease-out;
-    }
 }
 
-.links {
+.form {
     display: flex;
-    flex-wrap: wrap;
-    gap: 40px;
-    list-style: none;
+    flex-direction: column;
+    gap: 25px;
+}
 
-    .label {
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    span {
         color: $text-secondary;
-        margin-bottom: 5px;
+        font-size: $heading5;
     }
 
-    a {
-        text-decoration: underline;
-        text-underline-offset: 4px;
+    input,
+    textarea {
+        font: inherit;
+        color: $text-primary;
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid $title-accent;
+        padding: 8px 0;
+        resize: vertical;
 
-        &:hover {
-            color: $sharp-accent;
+        &:focus {
+            outline: none;
+            border-bottom-color: $sharp-accent;
         }
     }
 }
 
-@keyframes slideUp {
-    0% { transform: translateY(100%); }
-    50% { transform: translateY(100%); }
-    100% { transform: translateY(0%); }
+.submit {
+    align-self: flex-start;
+    font: inherit;
+    font-size: $heading5;
+    color: $text-primary;
+    background: transparent;
+    border: 1px solid $title-accent;
+    padding: 10px 30px;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+        border-color: $sharp-accent;
+        color: $sharp-accent;
+    }
+    &:disabled {
+        color: $text-secondary;
+        cursor: default;
+    }
 }
-@keyframes slideDown {
-    0% { transform: translateY(-100%); }
-    50% { transform: translateY(-100%); }
-    100% { transform: translateY(0%); }
+
+.sent {
+    font-size: $heading5;
+}
+
+.error {
+    color: $sharp-accent;
+
+    a {
+        text-decoration: underline;
+    }
+}
+
+// Bots fill this in; people never see it.
+.honeypot {
+    display: none;
 }
 
 @media (max-width: 530px){
-    .title{
-        font-size: $heading3;
+    .contact {
+        padding: 30px;
     }
 }

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -1,0 +1,71 @@
+@import '../variables.scss';
+
+.contact {
+    min-height: 100vh;
+    padding: 50px;
+
+    display: flex;
+    flex-direction: column;
+}
+
+.body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 60px;
+}
+
+.title {
+    display: grid;
+    line-height: 1;
+
+    span {
+        overflow: hidden;
+    }
+    span p {
+        animation: slideUp 0.75s ease-out;
+    }
+    .accent p {
+        color: $title-accent;
+        animation: slideDown 1.5s ease-out;
+    }
+}
+
+.links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 40px;
+    list-style: none;
+
+    .label {
+        color: $text-secondary;
+        margin-bottom: 5px;
+    }
+
+    a {
+        text-decoration: underline;
+        text-underline-offset: 4px;
+
+        &:hover {
+            color: $sharp-accent;
+        }
+    }
+}
+
+@keyframes slideUp {
+    0% { transform: translateY(100%); }
+    50% { transform: translateY(100%); }
+    100% { transform: translateY(0%); }
+}
+@keyframes slideDown {
+    0% { transform: translateY(-100%); }
+    50% { transform: translateY(-100%); }
+    100% { transform: translateY(0%); }
+}
+
+@media (max-width: 530px){
+    .title{
+        font-size: $heading3;
+    }
+}

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 40px;
+    gap: 80px;
 }
 
 .title {

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -1,5 +1,9 @@
 @import '../variables.scss';
 
+// Local to this component. Promote it to variables.scss if anything else
+// ever needs a non-text white.
+$highlight: #ffffff;
+
 .contact {
     min-height: 100vh;
     padding: 50px;
@@ -49,10 +53,11 @@
         border-bottom: 1px solid $title-accent;
         padding: 8px 0;
         resize: vertical;
+        transition: border-color 0.25s ease;
 
         &:focus {
             outline: none;
-            border-bottom-color: $text-primary;
+            border-bottom-color: $highlight;
         }
     }
 }
@@ -66,10 +71,11 @@
     border: 1px solid $title-accent;
     padding: 10px 30px;
     cursor: pointer;
+    transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
 
     &:hover:not(:disabled) {
-        border-color: $text-primary;
-        background: $text-primary;
+        border-color: $highlight;
+        background: $highlight;
         color: $pseudo-black;
     }
     &:disabled {

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -52,7 +52,7 @@
 
         &:focus {
             outline: none;
-            border-bottom-color: $sharp-accent;
+            border-bottom-color: $text-primary;
         }
     }
 }
@@ -68,8 +68,9 @@
     cursor: pointer;
 
     &:hover:not(:disabled) {
-        border-color: $sharp-accent;
-        color: $sharp-accent;
+        border-color: $text-primary;
+        background: $text-primary;
+        color: $pseudo-black;
     }
     &:disabled {
         color: $text-secondary;

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,18 +1,12 @@
 import type { Metadata } from 'next'
 import styles from './contact.module.scss'
 import Nav from '../components/nav/nav'
+import ContactForm from './contact-form'
 
 export const metadata: Metadata = {
   title: 'Contact | Abdullah Morrison',
   description: 'Get in touch with Abdullah Morrison.',
 }
-
-const links = [
-  { label: 'Email', value: 'abdullahmorrison@gmail.com', url: 'mailto:abdullahmorrison@gmail.com' },
-  { label: 'LinkedIn', value: 'in/abdullah-morrison', url: 'https://linkedin.com/in/abdullah-morrison' },
-  { label: 'GitHub', value: 'abdullahmorrison', url: 'https://github.com/abdullahmorrison' },
-  { label: 'Resume', value: 'View', url: 'https://abdullahmorrison.github.io/resume/' },
-]
 
 export default function Contact() {
   return (
@@ -20,24 +14,8 @@ export default function Contact() {
       <Nav/>
 
       <div className={styles.body}>
-        <h1 className={styles.title}>
-          <span><p>Get in</p></span>
-          <span className={styles.accent}><p>touch</p></span>
-        </h1>
-
-        <ul className={styles.links}>
-          {links.map(link => (
-            <li key={link.label}>
-              <h5 className={styles.label}>{link.label}</h5>
-              <a
-                href={link.url}
-                target={link.url.startsWith('mailto:') ? undefined : '_blank'}
-              >
-                {link.value}
-              </a>
-            </li>
-          ))}
-        </ul>
+        <h2 className={styles.title}>Contact</h2>
+        <ContactForm/>
       </div>
     </main>
   )

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import styles from './contact.module.scss'
+import Nav from '../components/nav/nav'
+
+export const metadata: Metadata = {
+  title: 'Contact | Abdullah Morrison',
+  description: 'Get in touch with Abdullah Morrison.',
+}
+
+const links = [
+  { label: 'Email', value: 'abdullahmorrison@gmail.com', url: 'mailto:abdullahmorrison@gmail.com' },
+  { label: 'LinkedIn', value: 'in/abdullah-morrison', url: 'https://linkedin.com/in/abdullah-morrison' },
+  { label: 'GitHub', value: 'abdullahmorrison', url: 'https://github.com/abdullahmorrison' },
+  { label: 'Resume', value: 'View', url: 'https://abdullahmorrison.github.io/resume/' },
+]
+
+export default function Contact() {
+  return (
+    <main className={styles.contact}>
+      <Nav/>
+
+      <div className={styles.body}>
+        <h1 className={styles.title}>
+          <span><p>Get in</p></span>
+          <span className={styles.accent}><p>touch</p></span>
+        </h1>
+
+        <ul className={styles.links}>
+          {links.map(link => (
+            <li key={link.label}>
+              <h5 className={styles.label}>{link.label}</h5>
+              <a
+                href={link.url}
+                target={link.url.startsWith('mailto:') ? undefined : '_blank'}
+              >
+                {link.value}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
Adds `/contact` — a name, email and message form wired to Netlify Forms, so messages arrive by email with no backend.

Netlify detects forms by scanning static HTML at deploy time and never sees React output, so the form is declared twice: once in `public/__forms.html` for detection, once as the real React form. Submissions POST there url-encoded. A hidden `bot-field` honeypot absorbs obvious spam.

Nav's Contact was a raw `mailto:` and now points here. Its Home link had an empty `href`, which resolves to the current page rather than the root — both are now `next/link`.

Verified locally: lint clean, build compiles, `/contact` prerenders static, and the output HTML carries `<form name="contact">` with all five fields.

Two things worth knowing:

- Netlify stores submissions but does not email them until you add a notification under Site configuration → Forms.
- The form cannot work on localhost. `/__forms.html` only accepts POSTs on a deployed site, so you will see the error state locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)